### PR TITLE
Add ionic-app-scripts to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ionic-angular": "3.1.1",
     "ionic-tags-input": "0.0.4",
     "ionicons": "3.0.0",
+        "ionic-app-scripts": "^3.2.4",
     "moment": "^2.18.1",
     "rxjs": "5.1.1",
     "sw-toolbox": "3.4.0",
@@ -53,6 +54,7 @@
   ],
   "cordovaPlatforms": [
     "ios",
+   
     {
       "platform": "ios",
       "version": "",


### PR DESCRIPTION
This pull request adds the ionic-app-scripts package to the dependencies in the package.json file to ensure it is available during production builds, resolving the build failure issue on Netlify.